### PR TITLE
chore: export lib to test reactSelect

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,5 @@
+import selectEvent from "react-select-event"
+
 export {
   styled,
   getCssText,
@@ -6,6 +8,8 @@ export {
   theme,
   config
 } from "./stitches.config"
+
+export { selectEvent }
 
 export { Alert } from "./components/Alert"
 export { Avatar } from "./components/Avatar"


### PR DESCRIPTION
Exportação da lib para testes no componente Select (react-select-event).

**motivo: evitar instalação desnecessária no projeto que será utilizada**